### PR TITLE
use standard repository field to point to git repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.6",
   "main": "dist/umd/vCards-ts.js",
   "description": "TypeScript vCard integration",
-  "git-repository": "https://github.com/digirati-labs/vCards-ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/digirati-labs/vCards-ts.git"
+  },
   "entry": "lib/index.ts",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
This will allow npmjs.com and other tools to point to the git repo